### PR TITLE
fixes n+1 query in postrequisites. closes #40.

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -14,9 +14,7 @@ class Course < ActiveRecord::Base
   end
 
   def postrequisites
-    Prerequisite.where('? = ANY(prerequisite_ids)', self.id).map do |prereq|
-      Course.find_by(id: prereq.postrequisite_id)
-    end
+    Course.where(id: Prerequisite.where('? = ANY(prerequisite_ids)', id).pluck(:postrequisite_id))
   end
 
   # Is this course currently schedulable?


### PR DESCRIPTION
I fixed up the post-requisites query, but when I started looking at the prereqs one, I realized that it was doing the queries that way to preserve the AND/OR relationships between the different prereqs for a course, so I left that one alone.

Tests all pass, but don't take my word for it.